### PR TITLE
Feat/checksum address

### DIFF
--- a/packages/contracts/src/libraries/SubjectUtils.sol
+++ b/packages/contracts/src/libraries/SubjectUtils.sol
@@ -11,6 +11,48 @@ import "../handlers/ExtensionHandler.sol";
 import "../EmailWalletCore.sol";
 
 library SubjectUtils {
+    bytes16 private constant LOWER_HEX_DIGITS = "0123456789abcdef";
+    bytes16 private constant UPPER_HEX_DIGITS = "0123456789ABCDEF";
+
+    function addressTChecksumHexString(address addr) internal pure returns (string memory) {
+        string memory lowerCaseAddrWithOx = Strings.toHexString(addr);
+
+        bytes memory lowerCaseAddr = new bytes(40); // Remove 0x added by the OZ lib
+        for (uint8 i = 2; i < 42; i++) {
+            lowerCaseAddr[i - 2] = bytes(lowerCaseAddrWithOx)[i];
+        }
+
+        // Hash of lowercase addr
+        uint256 lowerCaseHash = uint256(keccak256(abi.encodePacked(lowerCaseAddr)));
+
+        // Result hex = 42 chars with 0x prefix
+        bytes memory result = new bytes(42);
+        result[0] = "0";
+        result[1] = "x";
+
+        // Shift 24 bytes (96 bits) to the right; as we only need first 20 bytes of the hash to compare
+        lowerCaseHash >>= 24 * 4;
+
+        uint256 intAddr = uint256(uint160(addr));
+
+        for (uint8 i = 41; i > 1; --i) {
+            uint8 hashChar = uint8(lowerCaseHash & 0xf); // Get last char of the hex
+            uint8 addrChar = uint8(intAddr & 0xf); // Get last char of the address
+
+            if (hashChar >= 8) {
+                result[i] = UPPER_HEX_DIGITS[addrChar];
+            } else {
+                result[i] = LOWER_HEX_DIGITS[addrChar];
+            }
+
+            // Remove last char from both hash and addr
+            intAddr >>= 4;
+            lowerCaseHash >>= 4;
+        }
+
+        return string(result);
+    }
+
     /// @notice Convert bytes to hex string without 0x prefix
     /// @param data bytes to convert
     function bytesToHexString(bytes memory data) public pure returns (string memory) {
@@ -60,7 +102,7 @@ library SubjectUtils {
             if (emailOp.recipientETHAddr != address(0)) {
                 maskedSubject = string.concat(
                     maskedSubject,
-                    Strings.toHexString(uint256(uint160(emailOp.recipientETHAddr)), 20)
+                    addressTChecksumHexString(emailOp.recipientETHAddr)
                 );
             }
         }
@@ -113,7 +155,7 @@ library SubjectUtils {
             maskedSubject = string.concat(
                 Commands.EXIT_EMAIL_WALLET,
                 " Email Wallet. Change ownership to ",
-                Strings.toHexString(uint256(uint160(emailOp.newWalletOwner)), 20)
+                addressTChecksumHexString(emailOp.newWalletOwner)
             );
         }
         // Sample: DKIM registry as 0x000112aa..
@@ -123,7 +165,7 @@ library SubjectUtils {
             maskedSubject = string.concat(
                 Commands.DKIM,
                 " registry set to ",
-                Strings.toHexString(uint256(uint160(emailOp.newDkimRegistry)), 20)
+                addressTChecksumHexString(emailOp.newDkimRegistry)
             );
         }
         // The command is for an extension
@@ -186,13 +228,13 @@ library SubjectUtils {
                 // {addres} for wallet address
                 else if (Strings.equal(matcher, Commands.ADDRESS_TEMPLATE)) {
                     address addr = abi.decode(emailOp.extensionParams.subjectParams[nextParamIndex], (address));
-                    value = Strings.toHexString(uint256(uint160(addr)), 20);
+                    value = addressTChecksumHexString(addr);
                     nextParamIndex++;
                 }
                 // {recipient} is either the recipient's ETH address or zero bytes with the same length of the email address
                 else if (Strings.equal(matcher, Commands.RECIPIENT_TEMPLATE)) {
                     if (!emailOp.hasEmailRecipient) {
-                        value = Strings.toHexString(uint256(uint160(emailOp.recipientETHAddr)), 20);
+                        value = addressTChecksumHexString(emailOp.recipientETHAddr);
                     } else {
                         bytes memory zeros = new bytes(emailOp.numRecipientEmailAddrBytes);
                         value = string(zeros);

--- a/packages/contracts/test/EmailWalletCore.cmd.dkim.t.sol
+++ b/packages/contracts/test/EmailWalletCore.cmd.dkim.t.sol
@@ -19,7 +19,7 @@ contract DKIMRegistryCommandTest is EmailWalletCoreTestHelper {
         address dkimRegistryAddr = address(new TestDKIMRegistry());
         string memory subject = string.concat(
             "DKIM registry set to ",
-            Strings.toHexString(uint256(uint160(dkimRegistryAddr)), 20)
+            SubjectUtils.addressTChecksumHexString(dkimRegistryAddr)
         );
 
         EmailOp memory emailOp = _getBaseEmailOp();

--- a/packages/contracts/test/EmailWalletCore.cmd.exit.t.sol
+++ b/packages/contracts/test/EmailWalletCore.cmd.exit.t.sol
@@ -14,7 +14,7 @@ contract ExitCommandTest is EmailWalletCoreTestHelper {
         address newOwner = vm.addr(5);
         string memory subject = string.concat(
             "Exit Email Wallet. Change ownership to ",
-            Strings.toHexString(uint160(newOwner), 20)
+            SubjectUtils.addressTChecksumHexString(newOwner)
         );
         Wallet wallet = Wallet(payable(walletAddr));
 
@@ -35,7 +35,7 @@ contract ExitCommandTest is EmailWalletCoreTestHelper {
         address recipient = vm.addr(7);
 
         EmailOp memory sendEmailOp = _getBaseEmailOp();
-        string memory sendSubject = string.concat("Send 100 DAI to ", Strings.toHexString(uint160(recipient), 20));
+        string memory sendSubject = string.concat("Send 100 DAI to ", SubjectUtils.addressTChecksumHexString(recipient));
         sendEmailOp.command = Commands.SEND;
         sendEmailOp.walletParams.tokenName = "DAI";
         sendEmailOp.walletParams.amount = 100 ether;

--- a/packages/contracts/test/EmailWalletCore.cmd.extension.t.sol
+++ b/packages/contracts/test/EmailWalletCore.cmd.extension.t.sol
@@ -82,7 +82,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
 
         EmailOp memory emailOp = _getBaseEmailOp();
         emailOp.command = "NFT";
-        emailOp.maskedSubject = string.concat("NFT Send 22 of APE to ", Strings.toHexString(uint160(recipient), 20));
+        emailOp.maskedSubject = string.concat("NFT Send 22 of APE to ", SubjectUtils.addressTChecksumHexString(recipient));
         emailOp.extensionParams.subjectTemplateIndex = 0;
         emailOp.hasEmailRecipient = false;
         emailOp.recipientETHAddr = recipient;
@@ -137,7 +137,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
         emailOp.command = "Test";
         emailOp.maskedSubject = string.concat(
             "Test Sell for 23.2 DAI if 4.5 is between -5 and 10 then send to ",
-            Strings.toHexString(uint160(randomAddress), 20)
+            SubjectUtils.addressTChecksumHexString(randomAddress)
         );
         emailOp.extensionParams.subjectTemplateIndex = 8;
         emailOp.extensionParams.subjectParams = new bytes[](5);
@@ -211,7 +211,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
         emailOp.command = "NFT";
         emailOp.maskedSubject = string.concat(
             "Test Sell for 23 DAI if 4.5 is between -5 and 10 then send to ",
-            Strings.toHexString(uint160(randomAddress), 20)
+            SubjectUtils.addressTChecksumHexString(randomAddress)
         );
         emailOp.extensionParams.subjectTemplateIndex = 1;
         emailOp.extensionParams.subjectParams = new bytes[](4);
@@ -234,7 +234,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
         emailOp.command = "Test";
         emailOp.maskedSubject = string.concat(
             "Test Sell for 23 DAI if 4.5 is between -5 and 10 then send to ",
-            Strings.toHexString(uint160(randomAddress), 20)
+            SubjectUtils.addressTChecksumHexString(randomAddress)
         );
         emailOp.extensionParams.subjectTemplateIndex = 1;
         emailOp.extensionParams.subjectParams = new bytes[](6);
@@ -363,7 +363,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
 
         EmailOp memory emailOp = _getBaseEmailOp();
         emailOp.command = "Test";
-        emailOp.maskedSubject = string.concat("Test Execute on ", Strings.toHexString(uint160(randomAddress), 20));
+        emailOp.maskedSubject = string.concat("Test Execute on ", SubjectUtils.addressTChecksumHexString(randomAddress));
         emailOp.extensionParams.subjectTemplateIndex = 7;
         emailOp.extensionParams.subjectParams = new bytes[](1);
         emailOp.extensionParams.subjectParams[0] = abi.encode(randomAddress);
@@ -378,7 +378,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
     function test_RevertIf_ExecuteAsExtension_TargetIsCore() public {
         EmailOp memory emailOp = _getBaseEmailOp();
         emailOp.command = "Test";
-        emailOp.maskedSubject = string.concat("Test Execute on ", Strings.toHexString(uint160(address(core)), 20));
+        emailOp.maskedSubject = string.concat("Test Execute on ", SubjectUtils.addressTChecksumHexString(address(core)));
         emailOp.extensionParams.subjectTemplateIndex = 7;
         emailOp.extensionParams.subjectParams = new bytes[](1);
         emailOp.extensionParams.subjectParams[0] = abi.encode(address(core));
@@ -396,7 +396,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
         emailOp.command = "Test";
         emailOp.maskedSubject = string.concat(
             "Test Execute on ",
-            Strings.toHexString(uint160(address(unclaimsHandler)), 20)
+            SubjectUtils.addressTChecksumHexString(address(unclaimsHandler))
         );
         emailOp.extensionParams.subjectTemplateIndex = 7;
         emailOp.extensionParams.subjectParams = new bytes[](1);
@@ -413,7 +413,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
     function test_RevertIf_ExecuteAsExtension_TargetIsWallet() public {
         EmailOp memory emailOp = _getBaseEmailOp();
         emailOp.command = "Test";
-        emailOp.maskedSubject = string.concat("Test Execute on ", Strings.toHexString(uint160(walletAddr), 20));
+        emailOp.maskedSubject = string.concat("Test Execute on ", SubjectUtils.addressTChecksumHexString(walletAddr));
         emailOp.extensionParams.subjectTemplateIndex = 7;
         emailOp.extensionParams.subjectParams = new bytes[](1);
         emailOp.extensionParams.subjectParams[0] = abi.encode(walletAddr);
@@ -429,7 +429,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
     function test_RevertIf_ExecuteAsExtension_TargetIsToken() public {
         EmailOp memory emailOp = _getBaseEmailOp();
         emailOp.command = "Test";
-        emailOp.maskedSubject = string.concat("Test Execute on ", Strings.toHexString(uint160(address(usdcToken)), 20));
+        emailOp.maskedSubject = string.concat("Test Execute on ", SubjectUtils.addressTChecksumHexString(address(usdcToken)));
         emailOp.extensionParams.subjectTemplateIndex = 7;
         emailOp.extensionParams.subjectParams = new bytes[](1);
         emailOp.extensionParams.subjectParams[0] = abi.encode(address(usdcToken));
@@ -448,7 +448,7 @@ contract ExtensionCommandTest is EmailWalletCoreTestHelper {
 
         EmailOp memory emailOp = _getBaseEmailOp();
         emailOp.command = "Test";
-        emailOp.maskedSubject = string.concat("Test Execute on ", Strings.toHexString(uint160(randomAddress), 20));
+        emailOp.maskedSubject = string.concat("Test Execute on ", SubjectUtils.addressTChecksumHexString(randomAddress));
         emailOp.extensionParams.subjectTemplateIndex = 7;
         emailOp.extensionParams.subjectParams = new bytes[](1);
         emailOp.extensionParams.subjectParams[0] = abi.encode(randomAddress);

--- a/packages/contracts/test/EmailWalletCore.emailOp.t.sol
+++ b/packages/contracts/test/EmailWalletCore.emailOp.t.sol
@@ -145,7 +145,7 @@ contract EmailOpValidationTest is EmailWalletCoreTestHelper {
         EmailOp memory emailOp = _getTokenSendingEmailOp();
         emailOp.hasEmailRecipient = false;
         emailOp.recipientEmailAddrCommit = bytes32(uint256(123));
-        emailOp.maskedSubject = string.concat("Send 1 DAI to ", Strings.toHexString(uint256(uint160(recipient)), 20));
+        emailOp.maskedSubject = string.concat("Send 1 DAI to ", SubjectUtils.addressTChecksumHexString(recipient));
 
         vm.startPrank(relayer);
         vm.expectRevert("recipientEmailAddrCommit not allowed");
@@ -168,7 +168,7 @@ contract EmailOpValidationTest is EmailWalletCoreTestHelper {
 
     function test_ShouldReturnFeeIfUnclaimsNotRegistered() public {
         address recipient = vm.addr(5);
-        string memory subject = string.concat("Send 100 DAI to ", Strings.toHexString(uint160(recipient), 20));
+        string memory subject = string.concat("Send 100 DAI to ", SubjectUtils.addressTChecksumHexString(recipient));
 
         daiToken.freeMint(walletAddr, 150 ether);
 
@@ -194,7 +194,7 @@ contract EmailOpValidationTest is EmailWalletCoreTestHelper {
 
     function test_RelayerGasReimbursement_WhenUserPaysInETH() public {
         address recipient = vm.addr(5);
-        string memory subject = string.concat("Send 100 DAI to ", Strings.toHexString(uint160(recipient), 20));
+        string memory subject = string.concat("Send 100 DAI to ", SubjectUtils.addressTChecksumHexString(recipient));
 
         daiToken.freeMint(walletAddr, 150 ether);
 
@@ -226,7 +226,7 @@ contract EmailOpValidationTest is EmailWalletCoreTestHelper {
 
     function test_RelayerGasReimbursement_WhenUserPaysInToken() public {
         address recipient = vm.addr(5);
-        string memory subject = string.concat("Send 100 DAI to ", Strings.toHexString(uint160(recipient), 20));
+        string memory subject = string.concat("Send 100 DAI to ", SubjectUtils.addressTChecksumHexString(recipient));
 
         daiToken.freeMint(walletAddr, 150 ether);
         usdcToken.freeMint(walletAddr, 50 ether); // For gas  reimbursement
@@ -253,7 +253,7 @@ contract EmailOpValidationTest is EmailWalletCoreTestHelper {
 
     function test_RelayerGasReimbursement_WithCustomFeePerGas() public {
         address recipient = vm.addr(5);
-        string memory subject = string.concat("Send 100 DAI to ", Strings.toHexString(uint160(recipient), 20));
+        string memory subject = string.concat("Send 100 DAI to ", SubjectUtils.addressTChecksumHexString(recipient));
         uint256 feePerGas = 3 gwei;
 
         daiToken.freeMint(walletAddr, 150 ether);
@@ -339,7 +339,7 @@ contract EmailOpValidationTest is EmailWalletCoreTestHelper {
 
     function test_RevertIf_RelayerGasReimbursementFails() public {
         address recipient = vm.addr(5);
-        string memory subject = string.concat("Send 100 DAI to ", Strings.toHexString(uint160(recipient), 20));
+        string memory subject = string.concat("Send 100 DAI to ", SubjectUtils.addressTChecksumHexString(recipient));
 
         daiToken.freeMint(walletAddr, 150 ether);
         usdcToken.freeMint(walletAddr, 100 wei); // This is not enough for gas reimbursement

--- a/packages/contracts/test/EmailWalletCore.us.t.sol
+++ b/packages/contracts/test/EmailWalletCore.us.t.sol
@@ -132,7 +132,7 @@ contract UnclaimedStateTest is EmailWalletCoreTestHelper {
         emailOp.command = "Test";
         emailOp.maskedSubject = string.concat(
             "Test Register Unclaimed State to ",
-            Strings.toHexString(uint256(uint160(address(anotherExtension))), 20)
+            SubjectUtils.addressTChecksumHexString(address(anotherExtension))
         );
         emailOp.extensionParams.subjectTemplateIndex = 3;
         emailOp.hasEmailRecipient = true;

--- a/packages/contracts/test/helpers/EmailWalletCoreTestHelper.sol
+++ b/packages/contracts/test/helpers/EmailWalletCoreTestHelper.sol
@@ -21,6 +21,7 @@ import {RelayerHandler} from "../../src/handlers/RelayerHandler.sol";
 import {AccountHandler} from "../../src/handlers/AccountHandler.sol";
 import {UnclaimsHandler} from "../../src/handlers/UnclaimsHandler.sol";
 import {ExtensionHandler} from "../../src/handlers/ExtensionHandler.sol";
+import "../../src/libraries/SubjectUtils.sol";
 import "../../src/interfaces/Types.sol";
 import "../../src/interfaces/Commands.sol";
 


### PR DESCRIPTION
Use checksum address for subject

>  We need to calculate the Keccack-256 hash of the address in lowercase, without the ‘0x’ prefix.
Compare the ith character of both the address and the hash and if the ith character of the address is a letter and the ith character of the hash hex value is greater or equal to 8, set the ith character of the address to uppercase.