### PR TITLE
Change the behavior if the pool does not exist.

### DIFF
--- a/packages/contracts/src/extensions/PoolFinder.sol
+++ b/packages/contracts/src/extensions/PoolFinder.sol
@@ -32,4 +32,12 @@ contract PoolFinder {
         require(poolAddress != address(0), "Pool not found");
         return IUniswapV3Pool(poolAddress).slot0();
     }
+
+    function isPoolExists(        
+        address tokenA,
+        address tokenB,
+        uint24 fee
+    ) external view returns (bool) {
+        return factory.getPool(tokenA, tokenB, fee) != address(0);
+    }
 }

--- a/packages/contracts/test/EmailWalletCore.cmd.extension.uniswap.t.sol
+++ b/packages/contracts/test/EmailWalletCore.cmd.extension.uniswap.t.sol
@@ -79,6 +79,12 @@ contract UniswapExtensionCommandTest is EmailWalletCoreTestHelper {
 
         vm.startPrank(relayer);
 
+        // Mock for isPoolExists should return slot entity.
+        vm.mockCall(
+            address(uniExtension.poolFinder()),
+            abi.encodeWithSelector(PoolFinder.isPoolExists.selector),
+            abi.encode(true)
+        );
         // Mock for getPoolSlot0 should return slot entity.
         vm.mockCall(
             address(uniExtension.poolFinder()),
@@ -123,6 +129,12 @@ contract UniswapExtensionCommandTest is EmailWalletCoreTestHelper {
         // Mock for daiToken approval should return true.
         vm.mockCall(address(daiToken), abi.encodeWithSelector(TestERC20.approve.selector), abi.encode(true));
 
+        // Mock for isPoolExists should return slot entity.
+        vm.mockCall(
+            address(uniExtension.poolFinder()),
+            abi.encodeWithSelector(PoolFinder.isPoolExists.selector),
+            abi.encode(true)
+        );
         // Mock for getPoolSlot0 should return slot entity.
         vm.mockCall(
             address(uniExtension.poolFinder()),
@@ -167,6 +179,12 @@ contract UniswapExtensionCommandTest is EmailWalletCoreTestHelper {
         // Mock for usdcToken approval should return true.
         vm.mockCall(address(usdcToken), abi.encodeWithSelector(TestERC20.approve.selector), abi.encode(true));
 
+        // Mock for isPoolExists should return slot entity.
+        vm.mockCall(
+            address(uniExtension.poolFinder()),
+            abi.encodeWithSelector(PoolFinder.isPoolExists.selector),
+            abi.encode(true)
+        );
         // Mock for getPoolSlot0 should return slot entity.
         vm.mockCall(
             address(uniExtension.poolFinder()),
@@ -211,6 +229,12 @@ contract UniswapExtensionCommandTest is EmailWalletCoreTestHelper {
         // Mock for daiToken approval should return true.
         vm.mockCall(address(daiToken), abi.encodeWithSelector(TestERC20.approve.selector), abi.encode(true));
 
+        // Mock for isPoolExists should return slot entity.
+        vm.mockCall(
+            address(uniExtension.poolFinder()),
+            abi.encodeWithSelector(PoolFinder.isPoolExists.selector),
+            abi.encode(true)
+        );
         // Mock for getPoolSlot0 should return slot entity.
         vm.mockCall(
             address(uniExtension.poolFinder()),
@@ -251,6 +275,12 @@ contract UniswapExtensionCommandTest is EmailWalletCoreTestHelper {
 
         vm.startPrank(relayer);
 
+        // Mock for isPoolExists should return slot entity.
+        vm.mockCall(
+            address(uniExtension.poolFinder()),
+            abi.encodeWithSelector(PoolFinder.isPoolExists.selector),
+            abi.encode(true)
+        );
         // Mock for getPoolSlot0 should return slot entity.
         vm.mockCall(
             address(uniExtension.poolFinder()),
@@ -291,6 +321,12 @@ contract UniswapExtensionCommandTest is EmailWalletCoreTestHelper {
 
         vm.startPrank(relayer);
 
+        // Mock for isPoolExists should return slot entity.
+        vm.mockCall(
+            address(uniExtension.poolFinder()),
+            abi.encodeWithSelector(PoolFinder.isPoolExists.selector),
+            abi.encode(true)
+        );
         // Mock for getPoolSlot0 should return slot entity.
         vm.mockCall(
             address(uniExtension.poolFinder()),
@@ -332,6 +368,12 @@ contract UniswapExtensionCommandTest is EmailWalletCoreTestHelper {
 
         vm.startPrank(relayer);
 
+        // Mock for isPoolExists should return slot entity.
+        vm.mockCall(
+            address(uniExtension.poolFinder()),
+            abi.encodeWithSelector(PoolFinder.isPoolExists.selector),
+            abi.encode(true)
+        );
         // Mock for getPoolSlot0 should return slot entity.
         vm.mockCall(
             address(uniExtension.poolFinder()),


### PR DESCRIPTION
This PR enables that user can not use sqrt price limit parameter if the pool does not exist.
Because if the pool does not exist, anyone can not estimate correct sqrt price limit.
But, as long as the current sqrt price limit and slippage point are known, this parameter can be used.

Also, we already implemented 2 phase swaps, it can possible the token swap even if the tokenX -> tokenY pool does not exist.
I changed is statement condition from 

```
tokenInAddr != wethAddr && tokenOutAddr != wethAddr
```

to 

```
!isPoolExists
```

- [x] unit test
- [x] integration test