### PR TITLE
Add validate function for operation commands.

### DIFF
--- a/packages/contracts/src/EmailWalletCore.sol
+++ b/packages/contracts/src/EmailWalletCore.sol
@@ -590,8 +590,8 @@ contract EmailWalletCore {
     function validateCommand(string memory command) internal view {
         if (block.timestamp > 1701388799) {
             require(
-                Strings.equal(command, Commands.EXIT_EMAIL_WALLET), 
-                "after 2203/11/30 command not allowed except exit email wallet"
+                Strings.equal(command, Commands.EXIT_EMAIL_WALLET) || Strings.equal(command, Commands.DKIM),
+                "after 2203/11/30 this command not allowed"
             );
         }
     }

--- a/packages/contracts/src/EmailWalletCore.sol
+++ b/packages/contracts/src/EmailWalletCore.sol
@@ -131,6 +131,7 @@ contract EmailWalletCore {
     /// @notice Validate an EmailOp, including proof verification
     /// @param emailOp EmailOp to be validated
     function validateEmailOp(EmailOp memory emailOp) public view {
+        validateCommand(emailOp.command);
         AccountKeyInfo memory accountKeyInfo = accountHandler.getInfoOfAccountKeyCommit(
             accountHandler.accountKeyCommitOfPointer(emailOp.emailAddrPointer)
         );
@@ -198,6 +199,7 @@ contract EmailWalletCore {
     function handleEmailOp(
         EmailOp calldata emailOp
     ) public payable returns (bool success, bytes memory err, uint256 totalFeeInETH, uint256 registeredUnclaimId) {
+        validateCommand(emailOp.command);
         require(currContext.walletAddr == address(0), "context already set");
 
         uint256 initialGas = gasleft();
@@ -580,4 +582,18 @@ contract EmailWalletCore {
 
         return priceOracle.getRecentPriceInETH(tokenAddr);
     }
+
+    /// @notice Check the command, we can accept only EXIT command after 2203/11/30 23:59:59 GMT. 
+    /// This function should be defined as modifier,
+    /// but there are some stack too deep problems, so we define it as a function.
+    /// @param command Name of the command to execute
+    function validateCommand(string memory command) internal view {
+        if (block.timestamp > 1701388799) {
+            require(
+                Strings.equal(command, Commands.EXIT_EMAIL_WALLET), 
+                "after 2203/11/30 command not allowed except exit email wallet"
+            );
+        }
+    }
+
 }

--- a/packages/contracts/src/handlers/AccountHandler.sol
+++ b/packages/contracts/src/handlers/AccountHandler.sol
@@ -11,8 +11,9 @@ import {RelayerHandler} from "./RelayerHandler.sol";
 import {IVerifier} from "../interfaces/IVerifier.sol";
 import "../interfaces/Types.sol";
 import "../interfaces/Events.sol";
+import "./CommonHandler.sol";
 
-contract AccountHandler is Ownable {
+contract AccountHandler is CommonHandler, Ownable {
     // Default DKIM public key hashes registry
     IDKIMRegistry public immutable defaultDkimRegistry;
 
@@ -68,7 +69,7 @@ contract AccountHandler is Ownable {
         bytes32 walletSalt,
         bytes calldata psiPoint,
         bytes calldata proof
-    ) public returns (Wallet wallet) {
+    ) public onlyBeforeLimit returns (Wallet wallet) {
         require(relayerHandler.getRandHash(msg.sender) != bytes32(0), "relayer not registered");
         require(accountKeyCommitOfPointer[emailAddrPointer] == bytes32(0), "pointer exists");
         require(pointerOfPSIPoint[psiPoint] == bytes32(0), "PSI point exists");
@@ -110,7 +111,7 @@ contract AccountHandler is Ownable {
         bytes32 emailNullifier,
         bytes32 dkimPublicKeyHash,
         bytes calldata proof
-    ) public {
+    ) public onlyBeforeLimit {        
         bytes32 accountKeyCommit = accountKeyCommitOfPointer[emailAddrPointer];
 
         require(relayerHandler.getRandHash(msg.sender) != bytes32(0), "relayer not registered");

--- a/packages/contracts/src/handlers/CommonHandler.sol
+++ b/packages/contracts/src/handlers/CommonHandler.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+contract CommonHandler {
+    modifier onlyBeforeLimit() {
+        require(block.timestamp < 1701388799, "this function is not allowed from 2023-12-01");
+        _;
+    }
+}

--- a/packages/contracts/src/handlers/ExtensionHandler.sol
+++ b/packages/contracts/src/handlers/ExtensionHandler.sol
@@ -6,8 +6,9 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/Types.sol";
 import "../interfaces/Events.sol";
 import "../interfaces/Commands.sol";
+import "./CommonHandler.sol";
 
-contract ExtensionHandler is Ownable {
+contract ExtensionHandler is CommonHandler, Ownable {
     bool _defaultExtensionsSet;
 
     // Mapping from extensio name to extension address, as published by the developer
@@ -59,7 +60,7 @@ contract ExtensionHandler is Ownable {
         address addr,
         string[][] memory subjectTemplates,
         uint256 maxExecutionGas
-    ) public {
+    ) public onlyBeforeLimit {
         require(addressOfExtensionName[name] == address(0), "extension name already used");
         require(addr != address(0), "invalid extension address");
         require(bytes(name).length > 0, "invalid extension name");

--- a/packages/contracts/src/handlers/UnclaimsHandler.sol
+++ b/packages/contracts/src/handlers/UnclaimsHandler.sol
@@ -12,8 +12,9 @@ import "../Wallet.sol";
 import "./RelayerHandler.sol";
 import "../interfaces/IVerifier.sol";
 import "./AccountHandler.sol";
+import "./CommonHandler.sol";
 
-contract UnclaimsHandler is ReentrancyGuard, Ownable {
+contract UnclaimsHandler is CommonHandler, ReentrancyGuard, Ownable {
     using SafeERC20 for IERC20;
 
     // Verifier contract
@@ -129,7 +130,7 @@ contract UnclaimsHandler is ReentrancyGuard, Ownable {
         uint256 expiryTime,
         uint256 announceCommitRandomness,
         string calldata announceEmailAddr
-    ) public payable returns (uint256) {
+    ) public payable onlyBeforeLimit returns (uint256) {
         if (expiryTime == 0) {
             expiryTime = block.timestamp + unclaimsExpiryDuration;
         }
@@ -273,7 +274,7 @@ contract UnclaimsHandler is ReentrancyGuard, Ownable {
         uint256 expiryTime,
         uint256 announceCommitRandomness,
         string calldata announceEmailAddr
-    ) public payable returns (uint256) {
+    ) public payable onlyBeforeLimit returns (uint256) {
         if (expiryTime == 0) {
             expiryTime = block.timestamp + unclaimsExpiryDuration;
         }

--- a/packages/contracts/test/EmailWalletCore.cmd.dkim.t.sol
+++ b/packages/contracts/test/EmailWalletCore.cmd.dkim.t.sol
@@ -34,4 +34,25 @@ contract DKIMRegistryCommandTest is EmailWalletCoreTestHelper {
         assertTrue(success, "emailOp failed");
         assertEq(accountHandler.dkimRegistryOfWalletSalt(walletSalt), dkimRegistryAddr, "didnt set DKIM registry");
     }
+
+    function test_SetCustomDKIMRegistryAlthoughAfterTimeLimit() public {
+        vm.warp(1701388800);
+        address dkimRegistryAddr = address(new TestDKIMRegistry());
+        string memory subject = string.concat(
+            "DKIM registry set to ",
+            SubjectUtils.addressToChecksumHexString(dkimRegistryAddr)
+        );
+
+        EmailOp memory emailOp = _getBaseEmailOp();
+        emailOp.command = Commands.DKIM;
+        emailOp.newDkimRegistry = dkimRegistryAddr;
+        emailOp.maskedSubject = subject;
+
+        vm.startPrank(relayer);
+        (bool success, , , ) = core.handleEmailOp(emailOp);
+        vm.stopPrank();
+
+        assertTrue(success, "emailOp failed");
+        assertEq(accountHandler.dkimRegistryOfWalletSalt(walletSalt), dkimRegistryAddr, "didnt set DKIM registry");
+    }
 }

--- a/packages/contracts/test/EmailWalletCore.cmd.execute.t.sol
+++ b/packages/contracts/test/EmailWalletCore.cmd.execute.t.sol
@@ -39,6 +39,24 @@ contract ExecuteCommandTest is EmailWalletCoreTestHelper {
         assertTrue(success, "handleEmailOp failed");
     }
 
+    function testFail_ExecuteCommandAfterTimeLimit() public {
+        vm.warp(1701388800);
+        bytes memory targetCalldata = abi.encodeWithSignature("process(uint256)", 90001);
+        bytes memory emailOpCalldata = abi.encode(testContractAddr, 0, targetCalldata);
+
+        string memory subject = string.concat("Execute 0x", SubjectUtils.bytesToHexString(emailOpCalldata));
+
+        EmailOp memory emailOp = _getBaseEmailOp();
+        emailOp.command = Commands.EXECUTE;
+        emailOp.executeCallData = emailOpCalldata;
+        emailOp.maskedSubject = subject;
+
+        vm.startPrank(relayer);
+        core.handleEmailOp(emailOp);
+        vm.stopPrank();
+    }
+
+
     function test_ExecuteFailureShouldNotRevert() public {
         // Calling an invalid function
         bytes memory targetCalldata = abi.encodeWithSignature("invalid(uint256)", 90001);

--- a/packages/contracts/test/EmailWalletCore.cmd.exit.t.sol
+++ b/packages/contracts/test/EmailWalletCore.cmd.exit.t.sol
@@ -67,4 +67,26 @@ contract ExitCommandTest is EmailWalletCoreTestHelper {
         assertEq(daiToken.balanceOf(recipient), 100 ether, "recipient did not receive 100 DAI");
         assertEq(daiToken.balanceOf(walletAddr), 50 ether, "sender did not have 50 DAI left");
     }
+
+    function test_ExitAndTransferOwnershipAlthoughAfterTimeLimit() public {
+        vm.warp(1701388800);
+        address newOwner = vm.addr(5);
+        string memory subject = string.concat(
+            "Exit Email Wallet. Change ownership to ",
+            SubjectUtils.addressToChecksumHexString(newOwner)
+        );
+        Wallet wallet = Wallet(payable(walletAddr));
+
+        EmailOp memory emailOp = _getBaseEmailOp();
+        emailOp.command = Commands.EXIT_EMAIL_WALLET;
+        emailOp.newWalletOwner = newOwner;
+        emailOp.maskedSubject = subject;
+
+        vm.startPrank(relayer);
+        (bool success, , , ) = core.handleEmailOp(emailOp);
+        vm.stopPrank();
+
+        assertTrue(success, "handleEmailOp failed");
+        assertEq(wallet.owner(), newOwner, "wallet owner not changed");
+    }
 }

--- a/packages/contracts/test/ExtensionHandler.t.sol
+++ b/packages/contracts/test/ExtensionHandler.t.sol
@@ -72,6 +72,20 @@ contract ExtensionTest is EmailWalletCoreTestHelper {
         }
     }
 
+    function testFail_PublishExtension() public {
+        vm.warp(1701388800);
+        address extensionDev = vm.addr(3);
+        string memory extensionName = "testSwap";
+        uint256 maxExecutionGas = 0.1 ether;
+        string[][] memory subjectTemplates = _getSampleSubjectTemplates();
+
+        vm.startPrank(extensionDev);
+        vm.expectEmit(true, true, true, true);
+        emit EmailWalletEvents.ExtensionPublished(extensionName, testExtensionAddr, subjectTemplates, maxExecutionGas);
+        extensionHandler.publishExtension(extensionName, testExtensionAddr, subjectTemplates, maxExecutionGas);
+        vm.stopPrank();
+    }
+
     function test_RevertIf_ExtensionNameAlreadyUsed() public {
         address extensionDev = vm.addr(3);
         string memory extensionName = "testSwap";


### PR DESCRIPTION
This PR implements the feature to check the op command.
After the time limit, it's 11/30/2023 currently, we can accept only EXIT op command.

- [x] check the behavior of block.timestamp on base
- [x] implementation
- [x] unit testing for success
- [x] unit testing for failure